### PR TITLE
Associate *.xcf with krita.png

### DIFF
--- a/mod_autoindex-defaults-oxygen.conf
+++ b/mod_autoindex-defaults-oxygen.conf
@@ -68,7 +68,7 @@ Alias /icons/ "/usr/share/apache2/oxygen-icons/"
 	AddIcon /icons/sql.png .sql
 	AddIcon /icons/image.png .ico .png .jpeg .jpg
 	AddIcon /icons/plasma.png .plasmoid
-	AddIcon /icons/krita.png .kra
+	AddIcon /icons/krita.png .kra .xcf
 	AddIcon /icons/svg.png .svg .svgz
 	AddIcon /icons/desktop.png .desktop .kdelnk
 	AddIcon /icons/txt.png .txt .conf


### PR DESCRIPTION
Since `application-x-xcf.png` is a symlink to `application-x-krita.png` the icon for the two file types should be the same.